### PR TITLE
Feat/fitfrnd 33

### DIFF
--- a/back/user-service/src/main/java/com/example/userservice/controller/UserController.java
+++ b/back/user-service/src/main/java/com/example/userservice/controller/UserController.java
@@ -4,9 +4,7 @@ import com.example.userservice.common.dto.CustomResponseBody;
 import com.example.userservice.common.resolver.userid.UserId;
 import com.example.userservice.common.util.ResponseUtil;
 import com.example.userservice.domain.User;
-import com.example.userservice.dto.LoadUserDetailResponse;
-import com.example.userservice.dto.ModifyUserDetailRequest;
-import com.example.userservice.dto.SaveUserRequest;
+import com.example.userservice.dto.*;
 import com.example.userservice.service.UserService;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -50,8 +48,16 @@ public class UserController {
         return ResponseUtil.success(mapping);
     }
 
+    @PostMapping("/users/game-results")
+    ResponseEntity<CustomResponseBody<String>> applyGameResult(@RequestBody ApplyGameResultRequest request) {
+        userService.applyGameResult(request);
+        return ResponseUtil.success(null);
+    }
+
     @PutMapping("/users")
     String modifyUserDetail(@UserId UUID memberId , @RequestBody ModifyUserDetailRequest request) {
         return userService.modifyUserDetail(request, memberId);
     }
+
+
 }

--- a/back/user-service/src/main/java/com/example/userservice/domain/User.java
+++ b/back/user-service/src/main/java/com/example/userservice/domain/User.java
@@ -1,14 +1,9 @@
 package com.example.userservice.domain;
 
+import com.example.userservice.dto.GameResult;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.Collections;
 import java.util.UUID;
 
 @Getter
@@ -16,7 +11,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "users")
-public class User implements UserDetails {
+public class User{
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -38,7 +33,10 @@ public class User implements UserDetails {
 
     private String level;
 
-    @Column
+    private int matchCount = 0;
+
+    private int winCount = 0;
+
     private String accessToken;
 
     @ColumnDefault("1")
@@ -47,11 +45,9 @@ public class User implements UserDetails {
     @ColumnDefault("1")
     private boolean ageVisible;
 
-    @ColumnDefault("0")
-    private float winningRate;
+    private double winningRate = 0.0;
 
-    @ColumnDefault("0")
-    private float attendanceRate;
+    private double attendanceRate = 0.0;
 
     public User update(String name, String picture){
         this.name = name;
@@ -60,46 +56,16 @@ public class User implements UserDetails {
         return this;
     }
 
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority(this.role.getKey()));
-    }
-
-
-    @Override
-    public String getUsername() {
-        return email;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
+    public void updateWinningRate(GameResult gameResult){
+        this.matchCount++;
+        if(gameResult.equals(GameResult.WIN)) this.winCount++;
+        this.winningRate = Math.round(((double) this.winCount / this.matchCount * 100) * 100) / 100.0;
     }
 
     @Builder
-
-    public User(UUID userId, String name, String email, String picture, Role role, char gender, String age, String level, String accessToken, boolean genderVisible, boolean ageVisible, float winningRate, float attendanceRate) {
+    public User(UUID userId, String name, String email, String picture,
+                Role role, char gender, String age, String level, String accessToken,
+                boolean genderVisible, boolean ageVisible) {
         this.userId = userId;
         this.name = name;
         this.email = email;
@@ -111,7 +77,5 @@ public class User implements UserDetails {
         this.accessToken = accessToken;
         this.genderVisible = genderVisible;
         this.ageVisible = ageVisible;
-        this.winningRate = winningRate;
-        this.attendanceRate = attendanceRate;
     }
 }

--- a/back/user-service/src/main/java/com/example/userservice/dto/ApplyGameResultRequest.java
+++ b/back/user-service/src/main/java/com/example/userservice/dto/ApplyGameResultRequest.java
@@ -1,0 +1,17 @@
+package com.example.userservice.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class ApplyGameResultRequest {
+    private List<GameResultDto> gameresults;
+
+    @Getter
+    public static class GameResultDto {
+        private UUID userId;
+        private GameResult result;
+    }
+}

--- a/back/user-service/src/main/java/com/example/userservice/dto/GameResult.java
+++ b/back/user-service/src/main/java/com/example/userservice/dto/GameResult.java
@@ -1,0 +1,5 @@
+package com.example.userservice.dto;
+
+public enum GameResult {
+    WIN, LOSE, DRAW;
+}

--- a/back/user-service/src/main/java/com/example/userservice/dto/LoadUserDetailResponse.java
+++ b/back/user-service/src/main/java/com/example/userservice/dto/LoadUserDetailResponse.java
@@ -17,14 +17,14 @@ public class LoadUserDetailResponse {
     private char gender;
     private String age;
     private String level;
-    private float winningRate;
+    private double winningRate;
     private double attendanceRate;
     private Boolean isMyDetail;
 
     private List<ParticipationResponse> participationList;
 
     @Builder
-    public LoadUserDetailResponse(String name, String email, String picture, char gender, String age, String level, float winningRate, double attendanceRate, List<ParticipationResponse> participationList, Boolean isMyDetail) {
+    public LoadUserDetailResponse(String name, String email, String picture, char gender, String age, String level, double winningRate, double attendanceRate, List<ParticipationResponse> participationList, Boolean isMyDetail) {
         this.name = name;
         this.email = email;
         this.picture = picture;

--- a/back/user-service/src/main/java/com/example/userservice/service/AuthService.java
+++ b/back/user-service/src/main/java/com/example/userservice/service/AuthService.java
@@ -5,9 +5,6 @@ import com.example.userservice.common.dto.auth.JwtDto;
 import com.example.userservice.domain.User;
 import com.example.userservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -15,14 +12,10 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
-public class AuthService implements UserDetailsService {
+public class AuthService {
     private final UserRepository userRepository;
     private final JwtIssuer jwtIssuer;
 
-    @Override
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        return findByUserId(UUID.fromString(id)).get();
-    }
 
     public JwtDto socialSignIn(UUID userId) {
         User user = findByUserId(userId).get();

--- a/back/user-service/src/main/java/com/example/userservice/service/UserService.java
+++ b/back/user-service/src/main/java/com/example/userservice/service/UserService.java
@@ -4,20 +4,20 @@ import com.example.userservice.client.MatchServiceClient;
 import com.example.userservice.client.dto.ParticipationResponse;
 import com.example.userservice.common.exception.UserNotFoundException;
 import com.example.userservice.domain.User;
-import com.example.userservice.dto.LoadUserDetailResponse;
-import com.example.userservice.dto.ModifyUserDetailRequest;
-import com.example.userservice.dto.SaveUserRequest;
+import com.example.userservice.dto.*;
 import com.example.userservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
     private final MatchServiceClient matchServiceClient;
@@ -26,7 +26,6 @@ public class UserService {
         return userRepository.save(saveUserRequest.toEntity());
     }
 
-    @Transactional
     public LoadUserDetailResponse findUser(UUID userId, UUID me){
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new UserNotFoundException("User not found with ID: " + userId));
@@ -77,5 +76,14 @@ public class UserService {
             return "회원 정보 수정 오류";
         }
 
+    }
+
+    @Transactional
+    public void applyGameResult(ApplyGameResultRequest request) {
+        request.getGameresults()
+                .forEach(game -> {
+                    User user = userRepository.findByUserId(game.getUserId()).orElseThrow(() -> new UserNotFoundException("User not found with ID: " + game.getUserId()));
+                    user.updateWinningRate(game.getResult());
+                });
     }
 }

--- a/back/user-service/src/test/java/com/example/userservice/domain/UserTest.java
+++ b/back/user-service/src/test/java/com/example/userservice/domain/UserTest.java
@@ -1,0 +1,54 @@
+package com.example.userservice.domain;
+
+import com.example.userservice.dto.GameResult;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+class UserTest {
+
+    @Test
+    @DisplayName("승리한 경기인 경우 승률이 증가한다.")
+    void updateWinningRateWhenWin() {
+        User user = createUser();
+        int matchCount = 9;
+        user.setMatchCount(matchCount);
+        user.setWinCount(5);
+
+        user.updateWinningRate(GameResult.WIN);
+
+        Assertions.assertThat(user.getWinningRate()).isEqualTo(60.0);
+        Assertions.assertThat(user.getMatchCount()).isEqualTo(matchCount + 1);
+    }
+
+    @Test
+    @DisplayName("패배한 경기인 경우 승률이 감소한다.")
+    void updateWinningRateWhenLose() {
+        User user = createUser();
+        int matchCount = 49;
+        user.setMatchCount(matchCount);
+        user.setWinCount(5);
+
+        user.updateWinningRate(GameResult.LOSE);
+
+        Assertions.assertThat(user.getWinningRate()).isEqualTo(10.0);
+        Assertions.assertThat(user.getMatchCount()).isEqualTo(matchCount + 1);
+    }
+
+    private User createUser() {
+        return User.builder()
+                .name("Alexander Iqbal")
+                .email("alexanderiqbal@gmail.com")
+                .level("beginner")
+                .age("teens")
+                .picture("Nascetur erat ex fusce.")
+                .userId(UUID.randomUUID())
+                .genderVisible(true)
+                .ageVisible(true)
+                .gender('F')
+                .accessToken("Fermentum massa tellus lectus venenatis.")
+                .build();
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- user-service 참여자 게임 결과 설정 기능을 구현했습니다.
  - [관련 API 명세](https://seyeonpark.atlassian.net/wiki/spaces/F/pages/426004/API#%5BPOST%5D-%EC%B0%B8%EC%97%AC%EC%9E%90-%EA%B2%8C%EC%9E%84-%EA%B2%B0%EA%B3%BC-%EC%84%A4%EC%A0%95)
-  원래는 `winningRate` 와 `matchCount` 만 두고 승률을 갱신해야 할 때 승리 횟수를 저 두 값으로 복원하여 재계산하는 방식을 사용하려고 했는데, double 형이다보니 승리 횟수를 정수로 복원할 수가 없는 구조였습니다. 따라서 편리하게.. **USER** 엔티티에 `winCount` 필드를 추가하여 `matchCount`, `winningRate`, `winCount` 이 세 값을 모두 갱신하는 방법을 사용했습니다.
- winningRate 의 데이터 타입이 `float` 이었는데 항상 f를 붙여야 해서 `double` 로 바꿨습니다.

---

### ✨ 참고 사항
- 경기 이후 출석률 갱신도 이 api 에서 처리하기로 결정했었습니다! 이는 다음 스프린트 때 적용할 계획입니다.
---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #86 
