### PR TITLE
Feat/fitfrnd 27

### DIFF
--- a/back/apigateway-service/build.gradle
+++ b/back/apigateway-service/build.gradle
@@ -28,10 +28,8 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/back/apigateway-service/src/main/resources/application.yml
+++ b/back/apigateway-service/src/main/resources/application.yml
@@ -10,14 +10,6 @@ eureka:
 spring:
   application:
     name: apigateway-service
-  jpa:
-    hibernate:
-      ddl-auto: update
-  datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://address=(protocol=${DATASOURCE_PROTOCOL})(host=${DATASOURCE_HOST})(port=${DATASOURCE_PORT})/${DATABASE}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
   cloud:
     gateway:
       routes:
@@ -53,6 +45,14 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/post-service/(?<segment>.*), /$\{segment}
+            - AuthorizationHeaderFilter
+        - id: match-service
+          uri: lb://MATCH-SERVICE
+          predicates:
+            - Path=/match-service/**
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/match-service/(?<segment>.*), /$\{segment}
             - AuthorizationHeaderFilter
 
 token:

--- a/back/user-service/src/main/java/com/example/userservice/common/auth/SecurityConfig.java
+++ b/back/user-service/src/main/java/com/example/userservice/common/auth/SecurityConfig.java
@@ -1,16 +1,17 @@
 package com.example.userservice.common.auth;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
 
 @Configuration
 @EnableWebSecurity
@@ -29,6 +30,13 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.h2.console.enabled",havingValue = "true")
+    public WebSecurityCustomizer configureH2ConsoleEnable() {
+        return web -> web.ignoring()
+                .requestMatchers(PathRequest.toH2Console());
     }
 }
 

--- a/back/user-service/src/main/java/com/example/userservice/common/dto/CustomResponseBody.java
+++ b/back/user-service/src/main/java/com/example/userservice/common/dto/CustomResponseBody.java
@@ -1,8 +1,10 @@
 package com.example.userservice.common.dto;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class CustomResponseBody<T> {
     private String result;
     private int code;
@@ -15,5 +17,4 @@ public class CustomResponseBody<T> {
         this.message = message;
         this.data = data;
     }
-
 }

--- a/back/user-service/src/main/resources/application.yml
+++ b/back/user-service/src/main/resources/application.yml
@@ -1,12 +1,17 @@
 spring:
   application:
     name: user-service
-  h2:
-    console:
-      enabled: true
-      settings:
-        web-allow-others: true
-      path: /h2-console
+#  datasource:
+#    url: jdbc:h2:mem:testdb;
+#    driver-class-name: org.h2.Driver
+#    username: sa
+#    password:
+#  h2:
+#    console:
+#      enabled: true
+#      settings:
+#        web-allow-others: true
+#      path: /h2-console
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `user-service` 와 `match-service` 연동 완료 후 확인까지 마쳤습니다!
- `CustomResponseBody` 클래스에 기본생성자를 설정해줘야했습니다.
  - FeignClient 사용 시 응답을 dto 에 재대로 매핑하지 못해서 한참을 헤맸는데 이게 원인이었네요 😟
  - @jupyter471 꼭!!!!! `CustomResponseBody` 클래스에 기본생성자를 추가해주세요. 이번 커밋 변경사항 그대로 적용하시면 됩니당 
- `apigateway-service` 는 데이터베이스 연결이 불필요하기 때문에 데이터베이스 관련 설정 및 코드를 제거했습니다.

---

### ✨ 참고 사항

- h2 가 편하긴한데 마이크로 서비스 연결을 테스트하다보니 껐다가 켜야할 일이 많아서... 계속 데이터가 리셋되는 불편함 때문에 테스트는 mariadb 로 진행했습니다. `user-service` 의 application.yml 에 h2 관련 설정은 주석 처리해놨으므로 필요할 때 주석 해제하고 사용하시면 됩니다.

관련 API : 
- [특정 사용자가 참여한 participation 목록 조회](https://seyeonpark.atlassian.net/wiki/spaces/F/pages/426004/API#%5BGET%5D-%ED%8A%B9%EC%A0%95-%EC%82%AC%EC%9A%A9%EC%9E%90%EA%B0%80-%EC%B0%B8%EC%97%AC%ED%95%9C-participation-%EB%AA%A9%EB%A1%9D-%EC%A1%B0%ED%9A%8C-(%EC%9A%B0%EC%84%A0%EC%88%9C%EC%9C%84-%EB%86%92%EC%9D%8C))
- [user 정보 조회](https://seyeonpark.atlassian.net/wiki/spaces/F/pages/426004/API#%5BGET%5D-user-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C)




---

### ⏰ 현재 버그

x

---

### ✏ Git Close
