### PR TITLE
Feat/fitfrnd 28

### DIFF
--- a/back/apigateway-service/src/main/resources/application.yml
+++ b/back/apigateway-service/src/main/resources/application.yml
@@ -57,7 +57,7 @@ spring:
 
 token:
   expiration_time: 864000000
-  secret: ${TOKEN.SECRET}
+  secret: ${JWT.SECRET.KEY}
 
 logging:
   level:

--- a/back/match-service/src/main/resources/application.yml
+++ b/back/match-service/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+#  datasource:
+#    driver-class-name: org.mariadb.jdbc.Driver
+#    url: jdbc:mariadb://address=(protocol=${DATASOURCE_PROTOCOL})(host=${DATASOURCE_HOST})(port=${DATASOURCE_PORT})/${DATABASE}
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
   h2:
     console:
       enabled: true
@@ -27,8 +32,8 @@ eureka:
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
   client:
-    register-with-eureka: false
-    fetch-registry: false
+    register-with-eureka: true
+    fetch-registry: true
     service-url:
       defaultZone: ${EUREKA.SERVICE.URL}
 

--- a/back/post-service/build.gradle
+++ b/back/post-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+    implementation 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'

--- a/back/post-service/src/main/java/com/example/postservice/PostServiceApplication.java
+++ b/back/post-service/src/main/java/com/example/postservice/PostServiceApplication.java
@@ -3,9 +3,11 @@ package com.example.postservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableJpaAuditing
 public class PostServiceApplication {
 
     public static void main(String[] args) {

--- a/back/post-service/src/main/java/com/example/postservice/client/dto/SaveMatchRequest.java
+++ b/back/post-service/src/main/java/com/example/postservice/client/dto/SaveMatchRequest.java
@@ -1,15 +1,17 @@
 package com.example.postservice.client.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
+@AllArgsConstructor
 public class SaveMatchRequest {
     private UUID userId;
     private String category;
     private String place;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
-    private int headCnt;
+    private Integer headCnt;
 }

--- a/back/post-service/src/main/java/com/example/postservice/client/dto/SaveMatchResponse.java
+++ b/back/post-service/src/main/java/com/example/postservice/client/dto/SaveMatchResponse.java
@@ -1,0 +1,8 @@
+package com.example.postservice.client.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SaveMatchResponse {
+    private Long matchId;
+}

--- a/back/post-service/src/main/java/com/example/postservice/common/config/FeignConfig.java
+++ b/back/post-service/src/main/java/com/example/postservice/common/config/FeignConfig.java
@@ -1,12 +1,24 @@
 package com.example.postservice.common.config;
 
+import com.example.postservice.common.dto.CustomResponseBody;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import feign.FeignException;
 import feign.RequestInterceptor;
+import feign.Response;
+import feign.codec.Decoder;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringDecoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
 
 @Slf4j
 @Configuration
@@ -21,5 +33,32 @@ public class FeignConfig {
                 requestTemplate.header("Authorization", request.getHeader("Authorization"));
             }
         };
+    }
+
+    @Bean
+    public Decoder decoder(ObjectFactory<HttpMessageConverters> messageConverters) {
+        return new FeignDecoder(new SpringDecoder(messageConverters));
+    }
+
+    public static class FeignDecoder implements Decoder {
+        private final Decoder decoder;
+
+        public FeignDecoder(Decoder decoder) {
+            this.decoder = decoder;
+        }
+
+        @Override
+        public Object decode(Response response, Type type) throws IOException, FeignException {
+            var returnType = TypeFactory.rawClass(type);
+            var forClassWithGenerics =
+                    ResolvableType.forClassWithGenerics(CustomResponseBody.class, returnType);
+
+            try {
+                return ((CustomResponseBody<?>) decoder.decode(response,
+                        forClassWithGenerics.getType())).getData();
+            } catch (Exception e) {
+                return decoder.decode(response, forClassWithGenerics.getType());
+            }
+        }
     }
 }

--- a/back/post-service/src/main/java/com/example/postservice/common/dto/CustomResponseBody.java
+++ b/back/post-service/src/main/java/com/example/postservice/common/dto/CustomResponseBody.java
@@ -1,8 +1,10 @@
 package com.example.postservice.common.dto;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class CustomResponseBody<T> {
     private String result;
     private int code;

--- a/back/post-service/src/main/java/com/example/postservice/dto/PostIdResponse.java
+++ b/back/post-service/src/main/java/com/example/postservice/dto/PostIdResponse.java
@@ -1,10 +1,10 @@
 package com.example.postservice.dto;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@RequiredArgsConstructor
+@AllArgsConstructor
+@Getter
 public class PostIdResponse {
-    @NonNull
     private Long postId;
 }

--- a/back/post-service/src/main/java/com/example/postservice/service/PostService.java
+++ b/back/post-service/src/main/java/com/example/postservice/service/PostService.java
@@ -3,6 +3,7 @@ package com.example.postservice.service;
 import com.example.postservice.client.MatchServiceClient;
 import com.example.postservice.client.UserServiceClient;
 import com.example.postservice.client.dto.MatchResponse;
+import com.example.postservice.client.dto.SaveMatchRequest;
 import com.example.postservice.client.dto.UserResponse;
 import com.example.postservice.common.exception.PostNotFoundException;
 import com.example.postservice.domain.Post;
@@ -15,6 +16,7 @@ import com.example.postservice.repository.PostRepository;
 import com.example.postservice.repository.TagRepository;
 import jakarta.ws.rs.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +24,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class PostService {
     private final PostRepository postRepository;
     private final TagRepository tagRepository;
@@ -37,6 +41,7 @@ public class PostService {
 
         return posts.stream().map(post -> PostResponse.builder()
                 .title(post.getTitle())
+                .category(post.getCategory())
                 .createdDate(post.getCreatedDate())
                 .modifiedDate(post.getModifiedDate())
                 .tag(post.getTag())
@@ -57,6 +62,7 @@ public class PostService {
                 .title(post.getTitle())
                 .createdDate(post.getCreatedDate())
                 .modifiedDate(post.getModifiedDate())
+                .category(post.getCategory())
                 .tag(post.getTag())
                 .userName(user.getName())
                 .userImage(user.getPicture())
@@ -64,10 +70,15 @@ public class PostService {
                 .build();
     }
 
+    @Transactional
     public PostIdResponse save(AddPostRequest dto, UUID userId) {
         Tag tag = dto.tagToEntity();
         Tag savedTag = tagRepository.save(tag);
-        Long matchId = matchServiceClient.saveMatch(dto.getMatch());
+        Long matchId = matchServiceClient.saveMatch(
+                new SaveMatchRequest(
+                        userId, dto.getCategory(), dto.getMatch().getPlace(), dto.getMatch().getStartTime(), dto.getMatch().getEndTime(), dto.getMatch().getHeadCnt()
+                )
+        );
 
         Post post = dto.postToEntity(savedTag,matchId,userId);
         Post saved = postRepository.save(post);
@@ -75,6 +86,7 @@ public class PostService {
         return new PostIdResponse(saved.getPostId());
     }
 
+    @Transactional
     public void deleteById(UUID userId , Long id){
         if ((postRepository.findById(id).orElseThrow(PostNotFoundException::new)).getUserId().equals(userId)) {
             postRepository.deleteById(id);


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `post-service` 와 다른 마이크로 서비스를 연결했습니다. 
- `post-service` 에서 jpa auditing(createdDate, modifiedDate) 이 정상 작동하도록 `@EnableJpaAuditing` 어노테이션을 추가했습니다.
- `FeignConfig` 에 `CustomResponseBody`를 위한 decoder를 추가했습니다.
- `FeignClient` 의 decoder를 정상작동시키기 위해 `CustomResponseBody` 에 기본생성자 어노테이션을 추가했습니다.
- 아래 3개의 API 연동 확인했습니다.
  - [user 정보 조회](https://seyeonpark.atlassian.net/wiki/spaces/F/pages/426004/API#%5BGET%5D-user-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C)
  - [match 정보 조회](https://seyeonpark.atlassian.net/wiki/spaces/F/pages/426004/API#%5BGET%5D-match-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C)
  - [match 생성](https://seyeonpark.atlassian.net/wiki/spaces/F/pages/426004/API#%5BPOST%5D-match-%EC%83%9D%EC%84%B1)

---

### ✨ 참고 사항

- `discovery-service`가 왜 작동하지 않는지 알았습니다... 서비스에 필요한 환경변수가 하나 있어 디스커버리 서비스 프로젝트 하단에 .env를 따로 두고 실행하고 있었네욘... 한 파일로 모든 서비스를 실행할 수 있도록, back 폴더에 두는 .env 에 해당 환경변수 추가해뒀습니다. sorry..
  - [confluence .env 참고](https://seyeonpark.atlassian.net/wiki/x/NYEH) 

---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #71 
