### PR TITLE
FITFRND-38 게임 결과 설정 API에 출석률 업데이트 추가

### DIFF
--- a/back/user-service/src/main/java/com/example/userservice/controller/UserController.java
+++ b/back/user-service/src/main/java/com/example/userservice/controller/UserController.java
@@ -6,12 +6,8 @@ import com.example.userservice.common.util.ResponseUtil;
 import com.example.userservice.domain.User;
 import com.example.userservice.dto.*;
 import com.example.userservice.service.UserService;
-import com.fasterxml.jackson.databind.ser.FilterProvider;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.json.MappingJacksonValue;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;

--- a/back/user-service/src/main/java/com/example/userservice/domain/User.java
+++ b/back/user-service/src/main/java/com/example/userservice/domain/User.java
@@ -54,9 +54,17 @@ public class User{
     }
 
     public void updateWinningRate(GameResult gameResult){
-        this.matchCount++;
         if(gameResult.equals(GameResult.WIN)) this.winCount++;
         this.winningRate = Math.round(((double) this.winCount / this.matchCount * 100) * 100) / 100.0;
+    }
+
+    public void increaseMatchCount() {
+        this.matchCount++;
+    }
+
+    public void updateAttendanceRate(boolean attendance) {
+        if(attendance) this.attendanceRate += 1;
+        this.attendanceRate = Math.round((this.attendanceRate / this.matchCount * 100) * 100) / 100.0;
     }
 
     @Builder
@@ -74,4 +82,6 @@ public class User{
         this.genderVisible = genderVisible;
         this.ageVisible = ageVisible;
     }
+
+
 }

--- a/back/user-service/src/main/java/com/example/userservice/domain/User.java
+++ b/back/user-service/src/main/java/com/example/userservice/domain/User.java
@@ -34,6 +34,12 @@ public class User{
 
     private int winCount = 0;
 
+    private double winningRate = 0.0;
+
+    private int attendanceCount = 0;
+
+    private double attendanceRate = 0.0;
+
     private String accessToken;
 
     @ColumnDefault("1")
@@ -41,10 +47,6 @@ public class User{
 
     @ColumnDefault("1")
     private boolean ageVisible;
-
-    private double winningRate = 0.0;
-
-    private double attendanceRate = 0.0;
 
     public User update(String name, String picture){
         this.name = name;
@@ -63,8 +65,8 @@ public class User{
     }
 
     public void updateAttendanceRate(boolean attendance) {
-        if(attendance) this.attendanceRate += 1;
-        this.attendanceRate = Math.round((this.attendanceRate / this.matchCount * 100) * 100) / 100.0;
+        if(attendance) this.attendanceCount += 1;
+        this.attendanceRate = Math.round(((double) this.attendanceCount / this.matchCount * 100) * 100) / 100.0;
     }
 
     @Builder

--- a/back/user-service/src/main/java/com/example/userservice/dto/ApplyGameResultRequest.java
+++ b/back/user-service/src/main/java/com/example/userservice/dto/ApplyGameResultRequest.java
@@ -13,5 +13,6 @@ public class ApplyGameResultRequest {
     public static class GameResultDto {
         private UUID userId;
         private GameResult result;
+        private boolean attendance;
     }
 }

--- a/back/user-service/src/main/java/com/example/userservice/dto/ApplyGameResultRequest.java
+++ b/back/user-service/src/main/java/com/example/userservice/dto/ApplyGameResultRequest.java
@@ -13,6 +13,6 @@ public class ApplyGameResultRequest {
     public static class GameResultDto {
         private UUID userId;
         private GameResult result;
-        private boolean attendance;
+        private boolean attended;
     }
 }

--- a/back/user-service/src/main/java/com/example/userservice/service/UserService.java
+++ b/back/user-service/src/main/java/com/example/userservice/service/UserService.java
@@ -64,7 +64,7 @@ public class UserService {
     @Transactional
     public String modifyUserDetail(ModifyUserDetailRequest request, UUID userId) {
         try{
-            User user = userRepository.findByUserId(userId).get();
+            User user = userRepository.findByUserId(userId).orElseThrow(() -> new UserNotFoundException("User not found with ID: " + userId));
             user.setName(request.getName());
             user.setAgeVisible(request.isAgeVisible());
             user.setGenderVisible(request.isGenderVisible());
@@ -83,7 +83,7 @@ public class UserService {
                     User user = userRepository.findByUserId(game.getUserId()).orElseThrow(() -> new UserNotFoundException("User not found with ID: " + game.getUserId()));
                     user.increaseMatchCount();
                     user.updateWinningRate(game.getResult());
-                    user.updateAttendanceRate(game.isAttendance());
+                    user.updateAttendanceRate(game.isAttended());
                 });
     }
 }

--- a/back/user-service/src/main/java/com/example/userservice/service/UserService.java
+++ b/back/user-service/src/main/java/com/example/userservice/service/UserService.java
@@ -81,7 +81,9 @@ public class UserService {
         request.getGameresults()
                 .forEach(game -> {
                     User user = userRepository.findByUserId(game.getUserId()).orElseThrow(() -> new UserNotFoundException("User not found with ID: " + game.getUserId()));
+                    user.increaseMatchCount();
                     user.updateWinningRate(game.getResult());
+                    user.updateAttendanceRate(game.isAttendance());
                 });
     }
 }

--- a/back/user-service/src/test/java/com/example/userservice/domain/UserTest.java
+++ b/back/user-service/src/test/java/com/example/userservice/domain/UserTest.java
@@ -13,27 +13,50 @@ class UserTest {
     @DisplayName("승리한 경기인 경우 승률이 증가한다.")
     void updateWinningRateWhenWin() {
         User user = createUser();
-        int matchCount = 9;
+        int matchCount = 10;
         user.setMatchCount(matchCount);
         user.setWinCount(5);
 
         user.updateWinningRate(GameResult.WIN);
 
         Assertions.assertThat(user.getWinningRate()).isEqualTo(60.0);
-        Assertions.assertThat(user.getMatchCount()).isEqualTo(matchCount + 1);
     }
 
     @Test
     @DisplayName("패배한 경기인 경우 승률이 감소한다.")
     void updateWinningRateWhenLose() {
         User user = createUser();
-        int matchCount = 49;
+        int matchCount = 50;
         user.setMatchCount(matchCount);
         user.setWinCount(5);
 
         user.updateWinningRate(GameResult.LOSE);
 
         Assertions.assertThat(user.getWinningRate()).isEqualTo(10.0);
+    }
+
+    @Test
+    @DisplayName("출석률 업데이트에 성공한다.")
+    void updateAttendanceRate() {
+        User user = createUser();
+        int matchCount = 10;
+        user.setMatchCount(matchCount);
+        user.setAttendanceCount(8);
+
+        user.updateAttendanceRate(true);
+
+        Assertions.assertThat(user.getAttendanceRate()).isEqualTo(90.0);
+    }
+
+    @Test
+    @DisplayName("matchCount를 1 증가시킨다.")
+    void increaseMatchCount() {
+        User user = createUser();
+        int matchCount = 1;
+        user.setMatchCount(matchCount);
+
+        user.increaseMatchCount();
+
         Assertions.assertThat(user.getMatchCount()).isEqualTo(matchCount + 1);
     }
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 경기 결과 반영 시 출석 여부 정보가 추가되어, 사용자의 출석률을 업데이트하는 기능을 구현했습니다.
- AI 리뷰로 제안 받은 부분 다 적용했습니다.
- 원래 승률 업데이트 메서드 내에서 `matchCount` 를 1 증가시켰는데, 이제 승률, 출석률 모두 업데이트해야하므로 `matchCount` 를 1 증가시키는 메서드를 따로 만들어 뺐습니다.
  - 이에 따라 unit test 일부를 변경했습니다.  

---

### ✨ 참고 사항

- 유닛테스트는 다음주 중으로 올리겠습니다. (완료)
- 현재 올라온 `ApplyGameResultRequest` dto 의 출석 여부 필드가 API 명세에서의 필드명 (hasParticipated) 와 다릅니다. 

해당 필드가 **boolean** 이라 롬복 메서드 명이 아래와 같이 살짝 이상해지더라구요. 따라서 필드명을 `attended` 로 바꾸면 어떨까 제안드립니다! 확인 후 코멘트 남겨주세요 @jupyter471 
```
user.updateAttendanceRate(game.isHasParticipated());
```
---

### ⏰ 현재 버그

 x

---

### ✏ Git Close
- #96 
