### PR TITLE
FITFRND-39 docker container 구성 (discovery-service & apigateway-service)

### DIFF
--- a/back/apigateway-service/Dockerfile
+++ b/back/apigateway-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-ea-11-jdk-slim
+VOLUME /tmp
+COPY build/libs/apigateway-service-0.0.1-SNAPSHOT.jar ApigatewayService.jar
+ENTRYPOINT ["java", "-jar", "ApigatewayService.jar"]
+

--- a/back/apigateway-service/gradlew
+++ b/back/apigateway-service/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/back/apigateway-service/src/main/resources/application.yml
+++ b/back/apigateway-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: ${EUREKA.SERVICE.URL}
+      defaultZone: ${DOCKER.EUREKA.SERVICE.URL}
 
 spring:
   application:
@@ -15,7 +15,7 @@ spring:
       ddl-auto: update
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://address=(protocol=${DATASOURCE_PROTOCOL})(host=${DATASOURCE_HOST})(port=${DATASOURCE_PORT})/${DATABASE}
+    url: jdbc:mariadb://address=(protocol=${DATASOURCE_PROTOCOL})(host=${DOCKER_DATASOURCE_HOST})(port=${DATASOURCE_PORT})/${DATABASE}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   cloud:

--- a/back/discovery-service/Dockerfile
+++ b/back/discovery-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-ea-11-jdk-slim
+VOLUME /tmp
+COPY build/libs/discovery-service-0.0.1-SNAPSHOT.jar DiscoveryService.jar
+ENTRYPOINT ["java", "-jar", "DiscoveryService.jar"]


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `discovery-service` 와 `apigateway-service` 의 빠른 실행을 위해 docker container를 구성했습니다. 
- 이용 방법은 confluence를  참고해주세요.  [discovery-service & apigateway-service docker container 구성 방법]( https://seyeonpark.atlassian.net/wiki/x/AYCc)

---

### ✨ 참고 사항

- docker 로 실행하는 경우 mariadb container와 같은 네트워크에 속해야하기 때문에 환경변수 내용을 바꿨습니다.

#### 사용환경이 다른 경우에는 application.yml 에서 사용하는 환경변수를 아래와 같이 변경해주셔야 합니다.
- mariadb container 를 사용하지 않는 경우에는 `DOCKER_DATASOURCE_HOST` 대신 `DATASOURCE_HOST` 을 사용하시면 됩니다.
- `discovery-service` 를 IDE에서 직접 실행하는 경우에는 `DOCKER.EUREKA.SERVICE.URL` 대신 `EUREKA.SERVICE.URL` 을 사용하시면 됩니다.
  - 추후에 아예 env 파일을 분리하는게 좋을 것 같습니다!   

---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #99 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced containerization for both the API Gateway and Discovery services, enabling a more modern and consistent deployment environment.

- **Chores**
  - Updated configuration parameters for service discovery and database connections to align with the Docker environment.
  - Refined the build script's variable handling for improved consistency in runtime setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->